### PR TITLE
Fix (must not be accessed before initialization)?

### DIFF
--- a/src/sergittos/bedwars/session/Session.php
+++ b/src/sergittos/bedwars/session/Session.php
@@ -60,9 +60,9 @@ class Session {
     private ?int $respawn_time = null;
     private ?int $last_session_hit_time = null;
 
-    private int $coins;
-    private int $kills;
-    private int $wins;
+    private int $coins = 0;
+    private int $kills = 0;
+    private int $wins = 0;
 
     private bool $loading_data;
 


### PR DESCRIPTION
Error: Typed property sergittos\bedwars\session\Session::$coins must not be accessed before initialization
File: plugins/BedWars-master/src/sergittos/bedwars/session/Session
Line: 144
```
[142]     public function getCoins(): int
[143]     {
[144]         return $this->coins;
[145]     }
```